### PR TITLE
return EntitiesWrapper instance from EntityGetter instance

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,6 +16,7 @@
     "arrow-body-style": 0,
     "consistent-return": 1,
     "max-len": 0,
+    "no-underscore-dangle": ["error", { "allowAfterThis": true }],
     "no-use-before-define": [2, "nofunc"],
     "no-unused-expressions": 0,
     "no-console": 0,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-entity-getter",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "A helper class to query redux state for entities",
   "main": "lib/index.js",
   "scripts": {
@@ -35,15 +35,17 @@
     "babel-preset-react": "^6.3.13",
     "babel-preset-stage-0": "^6.5.0",
     "babel-runtime": "^6.3.19",
-    "eslint": "^2.5.0",
-    "eslint-config-airbnb": "^6.2.0",
-    "eslint-plugin-react": "^4.2.3",
-    "expect": "^1.14.0",
+    "eslint": "3.6.0",
+    "eslint-config-airbnb": "12.0.0",
+    "eslint-plugin-import": "1.16.0",
+    "eslint-plugin-jsx-a11y": "2.2.3",
+    "eslint-plugin-react": "6.3.0",
     "mocha": "^3.0.2",
     "rimraf": "^2.5.1",
     "webpack": "^1.12.12"
   },
   "dependencies": {
-    "lodash": "^4.15.0"
+    "expect": "^1.14.0",
+    "lodash": "4.16.4"
   }
 }

--- a/src/EntitiesWrapper/EntitiesWrapper.js
+++ b/src/EntitiesWrapper/EntitiesWrapper.js
@@ -1,0 +1,30 @@
+import { clone, each, filter, first } from 'lodash';
+
+class EntitiesWrapper {
+  constructor (entities = []) {
+    this.entities = entities;
+  }
+
+  findBy = (options = {}) => {
+    return first(this._filterEntities(options));
+  }
+
+  where = (options = {}) => {
+    return this._filterEntities(options);
+  }
+
+  _filterEntities = (options) => {
+    let filteredEntities = clone(this.entities);
+
+    each(options, (attributeValue, attributeName) => {
+      filteredEntities = filter(filteredEntities, (entity) => {
+        const attribute = entity[attributeName];
+        return String(attribute) === String(attributeValue);
+      });
+    });
+
+    return filteredEntities;
+  }
+}
+
+export default EntitiesWrapper;

--- a/src/EntitiesWrapper/EntitiesWrapper.tests.js
+++ b/src/EntitiesWrapper/EntitiesWrapper.tests.js
@@ -1,0 +1,63 @@
+import expect from 'expect';
+import EntitiesWrapper from './index';
+
+describe('EntitiesWrapper', () => {
+  const job1 = {
+    id: 1,
+    title: 'My job',
+    foo: 'bar',
+    number: 10,
+  };
+  const job2 = {
+    id: 2,
+    title: 'My job',
+    foo: 'bar',
+    number: 11,
+  };
+  const job3 = {
+    id: 3,
+    title: 'My other job',
+    foo: 'baz',
+    number: 10,
+  };
+  const entitiesWrapper = new EntitiesWrapper([job1, job2, job3]);
+
+  describe('entities', () => {
+    it('returns an array of entities', () => {
+      expect(entitiesWrapper.entities).toEqual([job1, job2, job3]);
+    });
+  });
+
+  describe('#findBy', () => {
+    it('finds the entity when comparing 1 attribute', () => {
+      expect(entitiesWrapper.findBy({ id: 1 })).toEqual(job1);
+    });
+
+    it('finds the entity when comparing multiple attributes', () => {
+      expect(entitiesWrapper.findBy({ title: 'My job', foo: 'bar' })).toEqual(job1);
+      expect(entitiesWrapper.findBy({ title: 'My job', number: 11 })).toEqual(job2);
+    });
+
+    it('returns undefined when no entities match', () => {
+      expect(entitiesWrapper.findBy({ something: 'wrong' })).toNotExist();
+      expect(entitiesWrapper.findBy({ title: 'My job', foo: 'baz' })).toNotExist();
+    });
+  });
+
+  describe('#where', () => {
+    it('filters state when comparing 1 attribute', () => {
+      expect(entitiesWrapper.where({ id: 1 })).toEqual([job1]);
+    });
+
+    it('filters state when comparing multiple attributes', () => {
+      expect(entitiesWrapper.where({ title: 'My job', foo: 'bar' })).toEqual([job1, job2]);
+      expect(entitiesWrapper.where({ title: 'My job', number: '11' })).toEqual([job2]);
+      expect(entitiesWrapper.entities).toEqual([job1, job2, job3]);
+    });
+
+    it('returns an empty array when no entities match', () => {
+      expect(entitiesWrapper.where({ something: 'wrong' })).toEqual([]);
+      expect(entitiesWrapper.where({ title: 'My job', foo: 'baz' })).toEqual([]);
+    });
+  });
+});

--- a/src/EntitiesWrapper/index.js
+++ b/src/EntitiesWrapper/index.js
@@ -1,0 +1,1 @@
+export default from './EntitiesWrapper';

--- a/src/EntityGetter/EntityGetter.js
+++ b/src/EntityGetter/EntityGetter.js
@@ -1,40 +1,20 @@
-import { clone, each, filter, first, get as _get, values } from 'lodash';
+import { get as _get, values } from 'lodash';
+
+import EntitiesWrapper from '../EntitiesWrapper';
 
 class EntityGetter {
   constructor (filterFunc, state) {
-    this.entities = [];
     this.filterFunc = filterFunc;
     this.state = state;
   }
 
   get = (entityName) => {
-    const { _filterEntities, filterFunc, state } = this;
+    const { filterFunc, state } = this;
     const pathToEntities = filterFunc(entityName);
+    const stateEntities = _get(state, pathToEntities);
+    const entities = values(stateEntities);
 
-    this.entities = _get(state, pathToEntities);
-
-    return {
-      entities: values(this.entities),
-      findBy: (options = {}) => {
-        return first(_filterEntities(options));
-      },
-      where: (options = {}) => {
-        return _filterEntities(options);
-      },
-    };
-  }
-
-  _filterEntities = (options) => {
-    let filteredEntities = clone(this.entities);
-
-    each(options, (attributeValue, attributeName) => {
-      filteredEntities = filter(filteredEntities, (entity) => {
-        const attribute = entity[attributeName];
-        return String(attribute) === String(attributeValue);
-      });
-    });
-
-    return filteredEntities;
+    return new EntitiesWrapper(entities);
   }
 }
 

--- a/src/EntityGetter/EntityGetter.tests.js
+++ b/src/EntityGetter/EntityGetter.tests.js
@@ -1,5 +1,6 @@
 import expect from 'expect';
 import entityGetter from './index';
+import EntitiesWrapper from '../EntitiesWrapper';
 
 describe('EntityGetter', () => {
   const job1 = {
@@ -40,42 +41,13 @@ describe('EntityGetter', () => {
     const getter = entityGetter(entitySelector)(state);
     const entities = getter.get('jobs');
 
+    it('returns an EntitiesWrapper object', () => {
+      expect(entities).toBeAn(EntitiesWrapper);
+    });
+
     describe('#entities', () => {
       it('returns an array of entities in state', () => {
         expect(entities.entities).toEqual([job1, job2, job3]);
-      });
-    });
-
-    describe('findBy', () => {
-      it('finds the entity when comparing 1 attribute', () => {
-        expect(entities.findBy({ id: 1 })).toEqual(job1);
-      });
-
-      it('finds the entity when comparing multiple attributes', () => {
-        expect(entities.findBy({ title: 'My job', foo: 'bar' })).toEqual(job1);
-        expect(entities.findBy({ title: 'My job', number: 11 })).toEqual(job2);
-      });
-
-      it('returns undefined when no entities match', () => {
-        expect(entities.findBy({ something: 'wrong' })).toNotExist();
-        expect(entities.findBy({ title: 'My job', foo: 'baz' })).toNotExist();
-      });
-    });
-
-    describe('#where', () => {
-      it('filters state when comparing 1 attribute', () => {
-        expect(entities.where({ id: 1 })).toEqual([job1]);
-      });
-
-      it('filters state when comparing multiple attributes', () => {
-        expect(entities.where({ title: 'My job', foo: 'bar' })).toEqual([job1, job2]);
-        expect(entities.where({ title: 'My job', number: '11' })).toEqual([job2]);
-        expect(entities.entities).toEqual([job1, job2, job3]);
-      });
-
-      it('returns an empty array when no entities match', () => {
-        expect(entities.where({ something: 'wrong' })).toEqual([]);
-        expect(entities.where({ title: 'My job', foo: 'baz' })).toEqual([]);
       });
     });
   });
@@ -99,42 +71,13 @@ describe('EntityGetter', () => {
     const getter = entityGetter(entitySelector)(state);
     const entities = getter.get('jobs');
 
+    it('returns an EntitiesWrapper object', () => {
+      expect(entities).toBeAn(EntitiesWrapper);
+    });
+
     describe('#entities', () => {
       it('returns an array of entities in state', () => {
         expect(entities.entities).toEqual([job1, job2, job3]);
-      });
-    });
-
-    describe('findBy', () => {
-      it('finds the entity when comparing 1 attribute', () => {
-        expect(entities.findBy({ id: 1 })).toEqual(job1);
-      });
-
-      it('finds the entity when comparing multiple attributes', () => {
-        expect(entities.findBy({ title: 'My job', foo: 'bar' })).toEqual(job1);
-        expect(entities.findBy({ title: 'My job', number: 11 })).toEqual(job2);
-      });
-
-      it('returns undefined when no entities match', () => {
-        expect(entities.findBy({ something: 'wrong' })).toNotExist();
-        expect(entities.findBy({ title: 'My job', foo: 'baz' })).toNotExist();
-      });
-    });
-
-    describe('#where', () => {
-      it('filters state when comparing 1 attribute', () => {
-        expect(entities.where({ id: 1 })).toEqual([job1]);
-      });
-
-      it('filters state when comparing multiple attributes', () => {
-        expect(entities.where({ title: 'My job', foo: 'bar' })).toEqual([job1, job2]);
-        expect(entities.where({ title: 'My job', number: '11' })).toEqual([job2]);
-        expect(entities.entities).toEqual([job1, job2, job3]);
-      });
-
-      it('returns an empty array when no entities match', () => {
-        expect(entities.where({ something: 'wrong' })).toEqual([]);
-        expect(entities.where({ title: 'My job', foo: 'baz' })).toEqual([]);
       });
     });
   });


### PR DESCRIPTION
This PR changes the return value of the `EntityGetter` class to return a new `EntitiesWrapper`. An `EntitiesWrapper` can "query" entities (using `#findBy` and `#where`), or return all entities (using `#entities`), which will return the actual entity objects in state.

I also updated a few packages as part of this update.
